### PR TITLE
Bump erp-run-test-suite role version to 2.1.0

### DIFF
--- a/erp-playbook/requirements.yml
+++ b/erp-playbook/requirements.yml
@@ -1,6 +1,6 @@
 - src: Linaro.erp-get-build
   version: 2.0.0
 - src: Linaro.erp-run-test-suite
-  version: 2.0.0
+  version: 2.1.0
 - src: Linaro.mr-provisioner
   version: 1.1.0


### PR DESCRIPTION
The new version includes the following improvements and bug fixes for
centos.

* enable epel-release repo to fix missing ngix package
* install python-pip from epel repo
* generate build_id with cache metadata

Signed-off-by: Chase Qi <chase.qi@linaro.org>